### PR TITLE
Made changes suggested in eigenvector chapter

### DIFF
--- a/source/10-eigenvectors-and-eigenvalues/sec01-eigenvectors.ptx
+++ b/source/10-eigenvectors-and-eigenvalues/sec01-eigenvectors.ptx
@@ -9,251 +9,181 @@
             <mrow> Ax = \lambda x </mrow>
         </md>
         <p>
-            Where <m>\lambda</m> is an arbitrary scalar constant, 
-            and valid values of <m>\lambda</m> are referred to as <term>eigenvalues</term>.
+            Here, <m>\lambda</m> is a scalar known as an <term>eigenvalue</term> 
+            associated with the eigenvector <m>x</m>.
+        </p>
+        <p>
+            In order to find the vectors, <m>x</m>, where the definition holds, 
+            we must first find the eigenvalues of <m>A</m>.
+            Then substitute the eigenvalues and row reduce.
+        </p>
+    </introduction>
+    <subsection xml:id="subsec-eigenvalues">
+        <title>Eigenvalues</title>
+        <p>
+            From the definition of an eigenvector we arrive 
+            at what is referred to as the <term>characteristic equation</term>:
+        </p>
+        <md>
+            <mrow> \det(A - \lambda I) = 0 </mrow>
+        </md>
+        <p>
+            The left hand side of this equation will evaluate to a polynomial with <m>\lambda</m> as the variable.
+            This is referred to as a <term>characteristic polynomial</term> and its roots are the eigenvalues of the matrix.
+        </p>
+        <p>
+            We will use the matrix <m>A</m> to demonstrate.
         </p>
         <sage>
             <input>
                 A = matrix([
-                        [6, 0],
-                        [4, 2]
-                ])
-                def EigenVis2D(T):
-                    if T.dimensions() != (2,2): raise Exception('Input must be a 2x2 matrix') #Tests for an appropriate matrix
-
-                    t = var('t') # Symbolic variable for parametric_plot
-                    V = matrix([[n1, n2] for n1 in range(-5,6) for n2 in range(-5,6)]).transpose() #Creates a matrix of the vectors, as columns, undergoing transformation, these will be represented as dots
-                    I = identity_matrix(2)
-                    if not T.eigenvectors_right()[0][0] in RealField():
-                        print("Complex eigenvalues, unable to plot eigenvectors and eigenspaces.")
-                        I_plot = list_plot(V.columns(), figsize=10)
-                    else:
-                        E_vectors = [vector for vector_list in [eigen_space[1] for eigen_space in T.eigenvectors_right()] for vector in vector_list ] # collects eigenvectors into a list E
-                        I_plot = list_plot(V.columns(), figsize=10) + sum(parametric_plot(t*(e/e.norm()), (t, -7, 7), color='green') for e in E_vectors) + sum(plot(e, color='green',) for e in E_vectors)
-
-                    # Display the numeric info about the transformation
-                    print("Eigen spaces: (Eigen Value, [Eigen Vectors])")
-                    %display latex
-                    show(var('T'), " = ", T)
-                    for e_space in T.eigenvectors_right(): show(e_space[0:2])
-                    %display plain
-
-                    T -= I
-                    Frames = [ # All frames of the animation are collected into a list
-                        I_plot + list_plot(((T*(n/30) + I)*V).columns(), color='red', ymin=-5, ymax=5, xmin=-5, xmax=5, figsize=6) for n in range(31)
-                    ]
-
-                    Frames = Frames + [Frames[-1]] * 16 # Padding extra end frames to make the animation stick to view the end of the transformation
-
-                    GIF = animate(Frames)
-                    GIF.show(delay=10)
-                EigenVis2D(A)
+                    [6, 0],
+                    [4, 2]
+                    ])
+                A
             </input>
         </sage>
-    </introduction>
+        <p>
+            First we will set <m>\lambda</m> as a variable.
+        </p>
+        <sage>
+            <input>
+                var('λ')
+            </input>
+            <output>
+                
+            </output>
+        </sage>
+        <p>
+            Then initialize <m>B = A - \lambda I</m>.
+        </p>
+        <sage>
+            <input>
+                B = A - λ * identity_matrix(2)
+                B
+            </input>
+            <output>
+                
+            </output>
+        </sage>
+        <p>
+            Then initialize <c>eq</c> with <m>\det(B) = 0</m> to solve symbolically.
+        </p>
+        <sage>
+            <input>
+                eq = B.det() == 0
+                eq
+            </input>
+            <output>
+                
+            </output>
+        </sage>
+        <p>
+            Then solve <c>eq</c>.
+        </p>
+        <sage>
+            <input>
+                solve(eq)
+            </input>
+            <output>
+                
+            </output>
+        </sage>
+        <p>
+            Sage has the <c>eigenvalues()</c> method to automatically compute the eigenvalues and return them as a list.
+        </p>
+        <sage>
+            <input>
+                A.eigenvalues()
+            </input>
+            <output>
+                
+            </output>
+        </sage>
+        <p>
+            We can use the <c>characteristic_polynomial()</c> 
+            method to directly obtain the characteristic polynomial, 
+            in terms of <m>x</m>, of a matrix.
+        </p>
+        <sage>
+            <input>
+                A.characteristic_polynomial()
+            </input>
+            <output>
+                
+            </output>
+        </sage>
+    </subsection>
     <subsection xml:id="subsec-computation-of-eigenvectors">
         <title>Computation of Eigenvectors</title>
         <p>
-            In order to find the vectors, <m>x</m>, where the definition holds, we must first find the eigenvalues of <m>A</m>.
-            Then substitute the eigenvalues and row reduce.
+            Recall the definition of an eigenvector which we used to solve for <m>\lambda</m>.
+            Using these eigenvalues we can create a matrix equation of the form:
         </p>
-        <subsubsection xml:id="subsubsec-eigenvalues">
-            <title>Eigenvalues</title>
+        <md>
+            <mrow> (A - \lambda I) x = 0 </mrow>
+        </md>
+        <note>
+        <title>Proof</title>
             <p>
-                From the definition of an eigenvector we arrive at what is referred to as the <term>characteristic equation</term>:
+                From the definition of eigenvectors we get:
             </p>
             <md>
-                <mrow> \det(A - \lambda I) = 0 </mrow>
+                <mrow> Ax = \lambda x </mrow>
             </md>
             <p>
-                The left hand side of this equation will evaluate to a polynomial with <m>\lambda</m> as the variable.
-                This is referred to as a <term>characteristic polynomial</term> and its roots are the eigenvalues of the matrix.
-            </p>
-            <p>
-                We will use the matrix <m>A</m> to demonstrate.
-            </p>
-            <sage>
-                <input>
-                    A = matrix([
-                        [6, 0],
-                        [4, 2]
-                        ])
-                    A
-                </input>
-            </sage>
-            <p>
-                We will use <c>l</c> to represent <m>\lambda</m>.
-            </p>
-            <sage>
-                <input>
-                    var('l')
-                </input>
-                <output>
-                    
-                </output>
-            </sage>
-            <p>
-                Then define <m>B = A - \lambda I</m>.
-            </p>
-            <sage>
-                <input>
-                    B = A - l * identity_matrix(2)
-                    B
-                </input>
-                <output>
-                    
-                </output>
-            </sage>
-            <p>
-                Then set <m>\det(B) = 0</m> to solve symbolically.
-            </p>
-            <sage>
-                <input>
-                    eq = B.det() == 0
-                    eq
-                </input>
-                <output>
-                    
-                </output>
-            </sage>
-            <p>
-                Then solve <c>eq</c>.
-            </p>
-            <sage>
-                <input>
-                    solve(eq)
-                </input>
-                <output>
-                    
-                </output>
-            </sage>
-            <note>
-                <title>Example by Hand</title>
-                <md>
-                    <mrow>
-                        \det\left(
-                        \begin{bmatrix}
-                            6 \amp 0 \\
-                            4 \amp 2
-                        \end{bmatrix}
-                        - \lambda
-                        \begin{bmatrix}
-                            1 \amp 0 \\
-                            0 \amp 1
-                        \end{bmatrix}
-                        \right) = 0
-                    </mrow>
-
-                    <mrow> 
-                        \begin{vmatrix}
-                            6 - \lambda \amp 0 \\
-                            4           \amp 2 - \lambda
-                        \end{vmatrix} = 0
-
-                    </mrow>
-
-                    <mrow> (6 - \lambda)(2 - \lambda) + 4 \cdot 0 = 0 </mrow>
-                    <mrow> (6 - \lambda)(2 - \lambda) = 0 </mrow>
-                    <mrow>\lambda_1 = 6, \hspace{12pt} \lambda_2 = 2 </mrow>
-                </md>
-            </note>
-            <p>
-                Sage has the <c>eigenvalues()</c> method to automatically compute the eigenvalues and return them as a list.
-            </p>
-            <sage>
-                <input>
-                    A.eigenvalues()
-                </input>
-                <output>
-                    
-                </output>
-            </sage>
-        </subsubsection>
-        <subsubsection xml:id="subsubsec-using-eigenvalues">
-            <title>Using Eigenvalues</title>
-            <p>
-                Recall the definition of an eigenvector which we used to solve for <m>\lambda</m>.
-                Using these eigenvalues we can create a matrix equation of the form:
+                Which becomes:
             </p>
             <md>
+                <mrow> Ax - \lambda x = 0 </mrow>
+                <mrow> Ax - \lambda I x = 0 </mrow>
                 <mrow> (A - \lambda I) x = 0 </mrow>
             </md>
             <p>
-                In the case of our example using <m>A</m> and choosing <m>\lambda = 6</m> this becomes:
+                Due to the assumption that <m>x \neq 0</m>,
+                this requires that <m>\det(A - \lambda I) = 0</m> 
+                for the equation above to hold.
             </p>
-            <md>
-                <mrow>
-                    \begin{bmatrix}
-                        6 - 6 \amp 0 \\
-                        4 \amp 2 - 6
-                    \end{bmatrix}
-                    \begin{bmatrix}
-                        x_1 \\ x_2
-                    \end{bmatrix}
-                    = 0
-                </mrow>
-            </md>
-            <p>
-                We can then convert this into an augmented matrix and row reduce.
-            </p>
-            <md>
-                <mrow>
-                    \left[\begin{array}{cc|c}
-                        6 - 6 \amp 0 \amp 0 \\
-                        4 \amp 2 - 6 \amp 0 \\
-                    \end{array}\right]
-                    \sim
-                    \left[\begin{array}{cc|c}
-                        0 \amp 0 \amp 0 \\
-                        1 \amp -1 \amp 0 \\
-                    \end{array}\right]
-                </mrow>
-            </md>
-            <p>
-                Which results in the parameterized equations and corresponding vector:
-            </p>
-            <md>
-                <mrow> 
-                    \left\{
-                       \begin{array}{c}
-                           0 = 0 \\
-                           x_1 - x_2 = 0
-                       \end{array}
-                    \right. 
-                    \hspace{6pt}
-                    \rightarrow
-                    \hspace{6pt}
-                    \left\{
-                        \begin{array}{c}
-                            x_1 = t \\
-                            x_2 = t
-                        \end{array}
-                     \right. 
-                     \hspace{6pt}
-                     \rightarrow
-                     \hspace{6pt}
-                     t
-                     \begin{bmatrix}
-                        1 \\ 1
-                     \end{bmatrix}
-                </mrow>
-            </md>
-            <p>
-                Recall we chose <m>\lambda = 6</m> so this eigenvector corresponds to the eigenvalue <m>6</m>.
-                In order to find the eigenvector corresponding to <m>\lambda = 2</m>, we repeat the process but instead chose <m>\lambda = 2</m>.
-            </p>
-            <p>
-                We can find all eigenvectors of <m>A</m> with the <c>eigenvectors_right()</c> method.
-            </p>
-            <sage>
-                <input>
-                    A.eigenvectors_right()
-                </input>
-            </sage>
-            <p>
-                The output is a list containing elements of the form <c>(e, [v_1, v_2, ... v_n], m)</c>, 
-                where <c>e</c> is the eigenvalue, <c>v_1</c> through <c>v_n</c> are the corresponding eigenvectors, and <c>m</c> is how many times <c>e</c> appears as a root in the characteristic polynomial (also referred to as algebraic multiplicity).
-            </p>
-        </subsubsection>
+        </note>
+        <p>
+            We can obtain <m>x</m> by substituting a value of <m>\lambda</m>, we will chose <m>\lambda = 6</m>. 
+        </p>
+        <sage>
+            <input>
+                B = A - 6 * identity_matrix(2)
+                B
+            </input>
+            <output>
+                
+            </output>
+        </sage>
+        <p>
+            Then using the <c>kernel()</c> method sage can solve this equation for us.
+            Since sage uses the left-kernel while our formula uses right multiplication, 
+            we must transpose <m>B</m> beforehand.
+        </p>
+        <sage>
+            <input>
+                B.transpose().kernel()
+            </input>
+            <output>
+                
+            </output>
+        </sage>
+        <p>
+            We can find all eigenvectors of <m>A</m> with the <c>eigenvectors_right()</c> method.
+        </p>
+        <sage>
+            <input>
+                A.eigenvectors_right()
+            </input>
+        </sage>
+        <p>
+            The output is a list containing elements of the form <c>(e, [v_1, v_2, ... v_n], m)</c>, 
+            where <c>e</c> is the eigenvalue, 
+            <c>v_1</c> through <c>v_n</c> are the corresponding eigenvectors, 
+            and <c>m</c> is how many times <c>e</c> 
+            appears as a root in the characteristic polynomial (also referred to as algebraic multiplicity).
+        </p>
     </subsection>
 </section>


### PR DESCRIPTION
## Description
### About kernel() usage
In the second to last sage cell, using the `.solve_right()` method results in a zero vector being returned instead of the correct eigenvector. I elected to use `kernel` and `transpose` instead. It is probably worth removing but I wanted to show off the only simple way to programmatically find eigenvectors without using the dedicated method.

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] New chapter (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [X] Refactor & clean up

## Checklist:
- [X] I have read the contributing guidelines.
- [ ] I have updated the documentation (if required).
- [X] I have checked my code and removed any unused variables or debug statements.
- [X] I have commented my code, and tested it locally.
